### PR TITLE
add region attribute description to README and fix spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The `aws_rds` LWRP manages a RDS instance
 - - Default VPC: true
 - - VPC: false If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be private.
 - `vpc_security_group_ids`: (Array) A list of Ec2 Vpc Security Groups to associate with this DB Instance. Default: The default Ec2 Vpc Security Group for the DB Subnet group's Vpc.
+- `region`: (String) The EC2 Availability Zone that the database instance will be created in. Default is us-east-1. 
 
 # Usage
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -7,7 +7,7 @@ attribute :aws_secret_access_key        , kind_of: String                 , requ
 attribute :allocated_storage            , kind_of: Integer                , required: true
 attribute :auto_minor_version_upgrade   , kind_of: [TrueClass,FalseClass] , default: true
 attribute :availability_zone            , kind_of: String
-attribute :region						, kind_of: String                 , default: 'us-east-1'
+attribute :region			, kind_of: String                 , default: 'us-east-1'
 attribute :backup_retention_period      , kind_of: Integer
 attribute :character_set_name           , kind_of: String
 attribute :db_instance_class            , kind_of: String                 , required: true


### PR DESCRIPTION
region was missing from the README and so I wasn't aware there was a default set until I got an error.
