### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The `aws_rds` LWRP manages a RDS instance
 In `metadata.rb` you should declare a dependency on this cookbook. For example:
 
 ```
-depends 'aws_rds'
+depends 'aws-rds'
 ```
 
 A recipe using this LWRP may look like this:


### PR DESCRIPTION
`depends 'aws_rds'` fails to find cookbook.  The cookbook name should be `aws-rds`.

Also, there may be an issue with having two different names for the cookbook such as `aws_rds` round in metadata.rb and `aws-rds` found in metadata.json.