### PR TITLE
Do not call db_parameter_group_name.

### DIFF
--- a/libraries/rds.rb
+++ b/libraries/rds.rb
@@ -60,7 +60,6 @@ module Overclock
         :db_instance_class            ,
         :db_instance_identifier       ,
         :db_name                      ,
-        :db_parameter_group_name      ,
         :engine                       ,
         :engine_version               ,
         :iops                         ,


### PR DESCRIPTION
Implements a fix for gosuri/aws-rds-cookbook#14.  The method
`db_parameter_group_name` does not exist in the AWS::RDS::DBInstance.
Calling the instance with that method will cause a no method error to be
thrown.
