### PR TITLE
Support storage_type attribute on rds resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The `aws_rds` LWRP manages a RDS instance
 - `preferred_backup_window`: (String) The daily time range during which automated backups are created if automated backups are enabled, as determined by the BackupRetentionPeriod.
 - `preferred_maintenance_window`: (String) The weekly time range (in UTC) during which system maintenance can occur.
 - `publicly_accessible`: (Boolean) Specifies the accessibility options for the DB Instance. A value of true specifies an Internet-facing instance with a publicly resolvable DNS name, which resolves to a public IP address. A value of false specifies an internal instance with a DNS name that resolves to a private IP address. Default: The default behavior varies depending on whether a VPC has been requested or not. The following list shows the default behavior in each case.
+- `storage_type`: (String) Specifies storage type to be associated with the DB Instance. Valid values: standard | gp2 | io1 If you specify io1, you must also include a value for the iops parameter.
 - `tags`: (Array) A list of tags to associate with this DB Instance. For example [{:key => 'bod', :value => "#{DateTime.now.to_s[0..18]}"}
 - - Default VPC: true
 - - VPC: false If no DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be publicly accessible. If a specific DB subnet group has been specified as part of the request and the PubliclyAccessible value has not been set, the DB instance will be private.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,4 +24,4 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-default[:aws_sdk_version] = "1.53.0"
+default[:aws_sdk_version] = "1.64.0"

--- a/libraries/rds.rb
+++ b/libraries/rds.rb
@@ -50,6 +50,7 @@ module Overclock
         :preferred_backup_window      ,
         :preferred_maintenance_window ,
         :publicly_accessible          ,
+        :storage_type                 ,
         :tags                         ,
         :vpc_security_group_ids
       ]

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -30,6 +30,7 @@ attribute :preferred_maintenance_window , kind_of: String
 attribute :publicly_accessible          , kind_of: [TrueClass,FalseClass] , default: false
 attribute :skip_final_snapshot          , kind_of: [TrueClass,FalseClass] , default: false
 attribute :region                       , kind_of: [String,NilClass]      , default: nil
+attribute :storage_type                 , kind_of: String
 attribute :tags                         , kind_of: Array
 attribute :vpc_security_group_ids       , kind_of: Array
 attribute :snapshot_id                  , kind_of: [String,NilClass]      , default: nil


### PR DESCRIPTION
RDS provisions database instances with magnetic storage by default.  This update allows setting the storage type attribute in the rds resource allowing us to use the 'gp2' (General Purpose SSD) for storage.

Also updated to the latest version (1.64.0) of aws-sdk library.